### PR TITLE
feature 17 prime login,logout count

### DIFF
--- a/sql/V7__create_topup.sql
+++ b/sql/V7__create_topup.sql
@@ -3,7 +3,8 @@
 	plan int not null,
 	recharge_on DATE not null ,
 	validity int not null,
+	screen int not null,
 	expires_on DATE not null,
 	check (plan in (399,699)),
-	
+	check (screen in (0,1,2))
 	);

--- a/src/main/java/in/venkat/exceptions/LoginLimitReachedException.java
+++ b/src/main/java/in/venkat/exceptions/LoginLimitReachedException.java
@@ -1,0 +1,10 @@
+package in.venkat.exceptions;
+
+public class LoginLimitReachedException extends Exception {
+
+	private static final long serialVersionUID = 1L;
+
+	public LoginLimitReachedException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/in/venkat/model/PrimeTopup.java
+++ b/src/main/java/in/venkat/model/PrimeTopup.java
@@ -3,11 +3,40 @@ package in.venkat.model;
 import java.time.LocalDate;
 
 public class PrimeTopup {
-
+	private int topupId;
 	private String userId;
 	private double cost;
 	private LocalDate rechargeDate;
 	private int validity;
+	private int screen;
+
+	public PrimeTopup(String userId, double cost, LocalDate rechargeDate, int validity, int screen,
+			LocalDate expiryDate) {
+		super();
+		this.userId = userId;
+		this.cost = cost;
+		this.rechargeDate = rechargeDate;
+		this.validity = validity;
+		this.screen = screen;
+		this.expiryDate = expiryDate;
+	}
+
+	public int getTopupId() {
+		return topupId;
+	}
+
+	public void setTopupId(int topupId) {
+		this.topupId = topupId;
+	}
+
+	public int getScreen() {
+		return screen;
+	}
+
+	public void setScreen(int screen) {
+		this.screen = screen;
+	}
+
 	private LocalDate expiryDate;
 
 	public String getUserId() {
@@ -50,30 +79,24 @@ public class PrimeTopup {
 		this.expiryDate = expiryDate;
 	}
 
-	public PrimeTopup(String userId, double cost, LocalDate rechargeDate, int validity, LocalDate expiryDate) {
-		super();
-		this.userId = userId;
-		this.cost = cost;
-		this.rechargeDate = rechargeDate;
-		this.validity = validity;
-		this.expiryDate = expiryDate;
-	}
-
 	public PrimeTopup(String userId) {
 		super();
 		this.userId = userId;
 	}
 
-	public PrimeTopup(String userId, LocalDate expiryDate) {
+	public PrimeTopup(int topupId, String userId, int plan, LocalDate expiryDate, int screen) {
 		super();
+		this.topupId = topupId;
 		this.userId = userId;
+		this.cost =plan;
 		this.expiryDate = expiryDate;
+		this.screen = screen;
 	}
 
 	@Override
 	public String toString() {
-		return "PrimeTopup [userId=" + userId + ", cost=" + cost + ", rechargeDate=" + rechargeDate + ", validity="
-				+ validity + ", expiryDate=" + expiryDate + "]";
+		return "PrimeTopup [topupId=" + topupId + ", userId=" + userId + ", cost=" + cost + ", rechargeDate="
+				+ rechargeDate + ", validity=" + validity + ", screen=" + screen + ", expiryDate=" + expiryDate + "]";
 	}
 
 }

--- a/src/main/java/in/venkat/service/PlansService.java
+++ b/src/main/java/in/venkat/service/PlansService.java
@@ -62,7 +62,7 @@ public class PlansService {
 	 */
 	public static LocalDate getExpiryDateById(String userId) throws DbException, InvalidUserIdException {
 		LocalDate expiryDate = null;
-		List<PrimeTopup> topupDetails = PrimeTopupDao.getExpiryDate();
+		List<PrimeTopup> topupDetails = PrimeTopupDao.getTopupDetails();
 		boolean validUser = false;
 		for (PrimeTopup topup : topupDetails) {
 			if (topup.getUserId().equals(userId)) {

--- a/src/main/java/in/venkat/service/PrimeTopupService.java
+++ b/src/main/java/in/venkat/service/PrimeTopupService.java
@@ -134,19 +134,18 @@ public class PrimeTopupService {
 		boolean valid = false;
 		int id = getValidId(userId);
 		int count = 0;
-		if (id > 0) {
-			double planCost = getPlanById(id);
-			count = getScreenCount(id);
-			if (planCost == 399 && count == 1) {
-				count--;
-				PrimeTopupDao.updateScreenStatus(id, count);
-			} else if (planCost == 699 && count > 0 && count <= 2) {
-				count--;
-				PrimeTopupDao.updateScreenStatus(id, count);
-			} else {
-				throw new LoginLimitReachedException("Your id has reached maximum no of screens");
-			}
+		double planCost = getPlanById(id);
+		count = getScreenCount(id);
+		if (planCost == 399 && count == 1 && id > 0) {
+			count--;
+			PrimeTopupDao.updateScreenStatus(id, count);
+		} else if (planCost == 699 && count > 0 && count <= 2 && id > 0) {
+			count--;
+			PrimeTopupDao.updateScreenStatus(id, count);
+		} else {
+			throw new LoginLimitReachedException("Your id has reached maximum no of screens");
 		}
+
 		return valid;
 	}
 
@@ -162,21 +161,15 @@ public class PrimeTopupService {
 	public static boolean logoutService(String userId) throws DbException, InvalidPlanException {
 		boolean valid = false;
 		int id = getValidId(userId);
-		Logger.log(id);
 		int count = 0;
-		if (id > 0) {
-			double planCost = getPlanById(id);
-			count = getScreenCount(id);
-			Logger.log(count);
-			if (planCost == 399 && count == 0) {
-				count++;
-				Logger.log(count);
-				PrimeTopupDao.updateScreenStatus(id, count);
-			} else if (planCost == 699 && count >= 0 && count < 2) {
-				count++;
-				Logger.log(count);
-				PrimeTopupDao.updateScreenStatus(id, count);
-			}
+		double planCost = getPlanById(id);
+		count = getScreenCount(id);
+		if (planCost == 399 && count == 0 && id > 0) {
+			count++;
+			PrimeTopupDao.updateScreenStatus(id, count);
+		} else if (planCost == 699 && count >= 0 && count < 2 && id > 0) {
+			count++;
+			PrimeTopupDao.updateScreenStatus(id, count);
 		} else {
 			throw new InvalidPlanException("there is no active plan recharge your account");
 		}

--- a/src/main/java/in/venkat/service/PrimeTopupService.java
+++ b/src/main/java/in/venkat/service/PrimeTopupService.java
@@ -14,7 +14,6 @@ import in.venkat.exceptions.LoginLimitReachedException;
 import in.venkat.exceptions.PlanNotExpiredException;
 import in.venkat.model.Plans;
 import in.venkat.model.PrimeTopup;
-import in.venkat.util.Logger;
 import in.venkat.validator.TopupValidation;
 import in.venkat.validator.ValidateUserDetails;
 

--- a/src/main/java/in/venkat/service/PrimeTopupService.java
+++ b/src/main/java/in/venkat/service/PrimeTopupService.java
@@ -8,10 +8,13 @@ import in.venkat.dao.PlansDao;
 import in.venkat.dao.PrimeTopupDao;
 import in.venkat.exceptions.DbException;
 import in.venkat.exceptions.InvalidChoiceException;
+import in.venkat.exceptions.InvalidPlanException;
 import in.venkat.exceptions.InvalidUserIdException;
+import in.venkat.exceptions.LoginLimitReachedException;
 import in.venkat.exceptions.PlanNotExpiredException;
 import in.venkat.model.Plans;
 import in.venkat.model.PrimeTopup;
+import in.venkat.util.Logger;
 import in.venkat.validator.TopupValidation;
 import in.venkat.validator.ValidateUserDetails;
 
@@ -40,16 +43,19 @@ public class PrimeTopupService {
 		boolean validTopup = PrimeTopupService.checkValidTopup(userId);
 		boolean validUserId = ValidateUserDetails.checkUserId(userId);
 		boolean isChoiceValid = TopupValidation.choiceValidation(choice);
+		int id = getValidId(userId);
 		List<Plans> plans = PlansDao.getPrimePlans();
 		int plan = 0;
 		int validity = 0;
+		int screen = 0;
 		for (Plans primePlans : plans) {
-			if (choice == primePlans.getPlanId() && validTopup && validUserId && isChoiceValid) {
+			if (choice == primePlans.getPlanId() && validTopup && validUserId && isChoiceValid && id == 0) {
 				plan = primePlans.getPrimePlans();
 				validity = primePlans.getPlanValidity();
+				screen = primePlans.getMovieScreens();
 				LocalDate today = LocalDate.now();
 				LocalDate expiryDate = today.plusDays(validity);
-				PrimeTopup primePlan = new PrimeTopup(userId, plan, today, validity, expiryDate);
+				PrimeTopup primePlan = new PrimeTopup(userId, plan, today, validity, screen, expiryDate);
 				PrimeTopupDao.saveTopupDetails(primePlan);
 			}
 		}
@@ -87,7 +93,7 @@ public class PrimeTopupService {
 	 */
 	public static LocalDate getExpiryDate(String userId) throws DbException {
 		LocalDate expiryDate = null;
-		List<PrimeTopup> topupExpiryDate = PrimeTopupDao.getExpiryDate();
+		List<PrimeTopup> topupExpiryDate = PrimeTopupDao.getTopupDetails();
 		for (PrimeTopup expiryCheck : topupExpiryDate) {
 			if (expiryCheck.getUserId().equals(userId)) {
 				expiryDate = expiryCheck.getExpiryDate();
@@ -106,13 +112,134 @@ public class PrimeTopupService {
 	 */
 	public static boolean isNewTopup(String userId) throws DbException {
 		boolean checkUser = false;
-		List<PrimeTopup> newTopup = PrimeTopupDao.getExpiryDate();
+		List<PrimeTopup> newTopup = PrimeTopupDao.getTopupDetails();
 		for (PrimeTopup userIdCheck : newTopup) {
 			if (userIdCheck.getUserId().equals(userId)) {
 				checkUser = true;
 			}
-
 		}
 		return checkUser;
+	}
+
+	/**
+	 * This method is for login when a new sign in occurs it will reduce the screen
+	 * count .
+	 * 
+	 * @param userId
+	 * @return
+	 * @throws DbException
+	 * @throws LoginLimitReachedException
+	 */
+	public static boolean loginService(String userId) throws DbException, LoginLimitReachedException {
+		boolean valid = false;
+		int id = getValidId(userId);
+		int count = 0;
+		if (id > 0) {
+			double planCost = getPlanById(id);
+			count = getScreenCount(id);
+			if (planCost == 399 && count == 1) {
+				count--;
+				PrimeTopupDao.updateScreenStatus(id, count);
+			} else if (planCost == 699 && count > 0 && count <= 2) {
+				count--;
+				PrimeTopupDao.updateScreenStatus(id, count);
+			} else {
+				throw new LoginLimitReachedException("Your id has reached maximum no of screens");
+			}
+		}
+		return valid;
+	}
+
+	/**
+	 * This method is used when any user logged out it will increase the screen
+	 * count
+	 * 
+	 * @param userId
+	 * @return
+	 * @throws DbException
+	 * @throws InvalidPlanException
+	 */
+	public static boolean logoutService(String userId) throws DbException, InvalidPlanException {
+		boolean valid = false;
+		int id = getValidId(userId);
+		Logger.log(id);
+		int count = 0;
+		if (id > 0) {
+			double planCost = getPlanById(id);
+			count = getScreenCount(id);
+			Logger.log(count);
+			if (planCost == 399 && count == 0) {
+				count++;
+				Logger.log(count);
+				PrimeTopupDao.updateScreenStatus(id, count);
+			} else if (planCost == 699 && count >= 0 && count < 2) {
+				count++;
+				Logger.log(count);
+				PrimeTopupDao.updateScreenStatus(id, count);
+			}
+		} else {
+			throw new InvalidPlanException("there is no active plan recharge your account");
+		}
+		return valid;
+	}
+
+	/**
+	 * This method is used to get the valid id whether it has active plans or not
+	 * 
+	 * @param userId
+	 * @return
+	 * @throws DbException
+	 */
+	public static int getValidId(String userId) throws DbException {
+		int id = 0;
+		boolean validDate = false;
+		List<PrimeTopup> topup = PrimeTopupDao.getTopupDetails();
+		for (PrimeTopup userTopup : topup) {
+			if (userTopup.getUserId().equals(userId)) {
+				validDate = TopupValidation.isValidExpirydate(userTopup.getExpiryDate());
+				if (!validDate) {
+					id = userTopup.getTopupId();
+					break;
+				}
+			}
+		}
+		return id;
+	}
+
+	/**
+	 * This method is used to get the screen count from the user
+	 * 
+	 * @param id
+	 * @return
+	 * @throws DbException
+	 */
+	public static int getScreenCount(int id) throws DbException {
+		int count = 0;
+		List<PrimeTopup> countScreen = PrimeTopupDao.getTopupDetails();
+		for (PrimeTopup plan : countScreen) {
+			if (plan.getTopupId() == id) {
+				count = plan.getScreen();
+			}
+		}
+		return count;
+
+	}
+
+	/**
+	 * This method is used to get the plans by recharged id
+	 * 
+	 * @param id
+	 * @return
+	 * @throws DbException
+	 */
+	public static double getPlanById(int id) throws DbException {
+		double planCost = 0;
+		List<PrimeTopup> plans = PrimeTopupDao.getTopupDetails();
+		for (PrimeTopup plan : plans) {
+			if (plan.getTopupId() == id) {
+				planCost = plan.getCost();
+			}
+		}
+		return planCost;
 	}
 }

--- a/src/main/java/in/venkat/service/UserService.java
+++ b/src/main/java/in/venkat/service/UserService.java
@@ -1,6 +1,5 @@
 package in.venkat.service;
 
-import java.lang.module.ModuleDescriptor.Builder;
 import java.sql.SQLException;
 import java.time.LocalDate;
 import java.util.List;
@@ -181,7 +180,7 @@ public class UserService {
 	 */
 	public static boolean isRechargeNotExpired(String userId) throws DbException {
 		boolean isValid = false;
-		List<PrimeTopup> recharge = PrimeTopupDao.getExpiryDate();
+		List<PrimeTopup> recharge = PrimeTopupDao.getTopupDetails();
 		for (PrimeTopup recharged : recharge) {
 			if (recharged.getUserId().equals(userId) && recharged.getExpiryDate().isBefore(LocalDate.now())) {
 				isValid = true;
@@ -189,6 +188,5 @@ public class UserService {
 		}
 		return isValid;
 	}
-
 
 }

--- a/src/main/java/in/venkat/validator/TopupValidation.java
+++ b/src/main/java/in/venkat/validator/TopupValidation.java
@@ -52,4 +52,17 @@ public class TopupValidation {
 		return isChoiceValid;
 	}
 
+	/**
+	 * This method is used to check whether the expire date is valid
+	 * 
+	 * @param expiryDate
+	 * @return
+	 */
+	public static boolean isValidExpirydate(LocalDate expiryDate) {
+		boolean valid = false;
+		if (LocalDate.now().isAfter(expiryDate) || (expiryDate.equals(LocalDate.now()))) {
+			valid = true;
+		}
+		return valid;
+	}
 }

--- a/src/test/java/in/venkat/serviceTest/PreferenceTest.java
+++ b/src/test/java/in/venkat/serviceTest/PreferenceTest.java
@@ -16,7 +16,6 @@ public class PreferenceTest {
 	}
 
 	private static void preference(String preferredLanguage) {
-
 		try {
 			if (NameValidationUtil.validateName(preferredLanguage)) {
 				ShowService.getPreferredMoviesByLanguage(preferredLanguage);

--- a/src/test/java/in/venkat/serviceTest/PrimeUserLoginTest.java
+++ b/src/test/java/in/venkat/serviceTest/PrimeUserLoginTest.java
@@ -1,0 +1,16 @@
+package in.venkat.serviceTest;
+
+import in.venkat.service.PrimeTopupService;
+import in.venkat.util.Logger;
+
+public class PrimeUserLoginTest {
+
+	public static void main(String[] args) {
+		try {
+			String userId = "venkat8767898760";
+			PrimeTopupService.loginService(userId);
+		} catch (Exception E) {
+			Logger.exception(E);
+		}
+	}
+}

--- a/src/test/java/in/venkat/serviceTest/PrimeUserLogoutTest.java
+++ b/src/test/java/in/venkat/serviceTest/PrimeUserLogoutTest.java
@@ -1,0 +1,19 @@
+package in.venkat.serviceTest;
+
+import in.venkat.exceptions.DbException;
+import in.venkat.exceptions.InvalidPlanException;
+import in.venkat.service.PrimeTopupService;
+import in.venkat.util.Logger;
+
+public class PrimeUserLogoutTest {
+
+	public static void main(String[] args) {
+		try {
+			String userId = "venkat8767898760";
+			PrimeTopupService.logoutService(userId);
+		} catch (DbException | InvalidPlanException e) {
+			Logger.exception(e);
+		}
+	}
+
+}

--- a/src/test/java/in/venkat/serviceTest/SearchByMovieNameTest.java
+++ b/src/test/java/in/venkat/serviceTest/SearchByMovieNameTest.java
@@ -26,7 +26,6 @@ public class SearchByMovieNameTest {
 			} else {
 				throw new EmptyFieldException("no movies with this name");
 			}
-
 		} catch (DbException | EmptyFieldException | InvalidNameException e) {
 			Logger.exception(e);
 		}

--- a/src/test/java/in/venkat/serviceTest/TopupTest.java
+++ b/src/test/java/in/venkat/serviceTest/TopupTest.java
@@ -14,13 +14,12 @@ public class TopupTest {
 	public static void main(String[] args) {
 
 		try {
-			String userId = "venkat9790430272";
-			int choice = 2;
+			String userId = "kumar8767898770";
+			int choice = 1;
 			PrimeTopupService.primeTopup(choice, userId);
 		} catch (DbException | InvalidUserIdException | PlanNotExpiredException | SQLException
 				| InvalidChoiceException e) {
 			Logger.exception(e);
 		}
-
 	}
 }


### PR DESCRIPTION
#### User story
* As the recharged prime member signed in the user screen is reduced 
* The 399 plan user can watch only one screen 
* The 699 plan user can watch on 2 screen as the user signed in the the screen count is reduced to 1 and they can sign in the prime id in only one device 
* And as soon as the user logged out the the screen count will be increased 
#### validation
* 399 plan has 1 screen limit 
* 600 plan has 2 screen limit 
#### table 
* prime_topup